### PR TITLE
Added test for insertLast on an empty list

### DIFF
--- a/exercises/linkedlist/test.js
+++ b/exercises/linkedlist/test.js
@@ -145,6 +145,14 @@ describe.skip('InsertLast', () => {
     expect(l.size()).toEqual(2);
     expect(l.getLast().data).toEqual('b');
   });
+
+  test('adds to the end of an empty list', () => {
+    const l = new List();
+    l.insertLast('a');
+
+    expect(l.size()).toEqual(1);
+    expect(l.getLast().data).toEqual('a');
+  });
 });
 
 describe.skip('GetAt', () => {


### PR DESCRIPTION
Added previously-untested case for running `insertLast()` on a linked list with no elements.